### PR TITLE
Allow creating more than one cluster under the same AD

### DIFF
--- a/scripts/Configure-WSFC.ps1
+++ b/scripts/Configure-WSFC.ps1
@@ -57,13 +57,13 @@ try {
     $ConfigWSFCPs={
         $nodes = $Using:WSFCNode1NetBIOSName, $Using:WSFCNode2NetBIOSName
         $addr =  $Using:WSFCNode1PrivateIP2, $Using:WSFCNode2PrivateIP2
-        New-Cluster -Name $WSFCName -Node $nodes -StaticAddress $addr
+        New-Cluster -Name $Using:WSFCName -Node $nodes -StaticAddress $addr
     }
     if ($WSFCNode3NetBIOSName) {
         $ConfigWSFCPs={
             $nodes = $Using:WSFCNode1NetBIOSName, $Using:WSFCNode2NetBIOSName, $Using:WSFCNode3NetBIOSName
             $addr =  $Using:WSFCNode1PrivateIP2, $Using:WSFCNode2PrivateIP2, $Using:WSFCNode3PrivateIP2
-            New-Cluster -Name WSFCluster1 -Node $nodes -StaticAddress $addr
+            New-Cluster -Name $Using:WSFCName -Node $nodes -StaticAddress $addr
         }
     }
 

--- a/scripts/Configure-WSFC.ps1
+++ b/scripts/Configure-WSFC.ps1
@@ -3,6 +3,10 @@ param(
 
     [Parameter(Mandatory=$true)]
     [string]
+    $WSFCName,
+    
+    [Parameter(Mandatory=$true)]
+    [string]
     $DomainNetBIOSName,
 
     [Parameter(Mandatory=$true)]
@@ -53,7 +57,7 @@ try {
     $ConfigWSFCPs={
         $nodes = $Using:WSFCNode1NetBIOSName, $Using:WSFCNode2NetBIOSName
         $addr =  $Using:WSFCNode1PrivateIP2, $Using:WSFCNode2PrivateIP2
-        New-Cluster -Name WSFCluster1 -Node $nodes -StaticAddress $addr
+        New-Cluster -Name $WSFCName -Node $nodes -StaticAddress $addr
     }
     if ($WSFCNode3NetBIOSName) {
         $ConfigWSFCPs={

--- a/templates/sql.template
+++ b/templates/sql.template
@@ -3550,6 +3550,10 @@
                                         "",
                                         [
                                             "powershell.exe -ExecutionPolicy RemoteSigned -Command \"C:\\cfn\\scripts\\Configure-WSFC.ps1",
+                                            " -WSFCName ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
                                             " -WSFCNode1PrivateIP2 ",
                                             {
                                                 "Ref": "WSFCNode1PrivateIP2"


### PR DESCRIPTION
Hi,
I need to create more than one cluster under the same AD and I found out it didn't work as Configure-WSFC.ps1 had the hard coded cluster name.
So, I changed the template and the script to use the stack name instead of the hard coded cluster name.
Thanks.