### PR TITLE
Add ability to specify the Cluster Virtual Name, fix Io1 volumetype...

### DIFF
--- a/scripts/Configure-WSFC.ps1
+++ b/scripts/Configure-WSFC.ps1
@@ -3,6 +3,10 @@ param(
 
     [Parameter(Mandatory=$true)]
     [string]
+    $WSFCName,
+
+    [Parameter(Mandatory=$true)]
+    [string]
     $DomainNetBIOSName,
 
     [Parameter(Mandatory=$true)]
@@ -53,13 +57,13 @@ try {
     $ConfigWSFCPs={
         $nodes = $Using:WSFCNode1NetBIOSName, $Using:WSFCNode2NetBIOSName
         $addr =  $Using:WSFCNode1PrivateIP2, $Using:WSFCNode2PrivateIP2
-        New-Cluster -Name WSFCluster1 -Node $nodes -StaticAddress $addr
+        New-Cluster -Name $Using:WSFCName -Node $nodes -StaticAddress $addr
     }
     if ($WSFCNode3NetBIOSName) {
         $ConfigWSFCPs={
             $nodes = $Using:WSFCNode1NetBIOSName, $Using:WSFCNode2NetBIOSName, $Using:WSFCNode3NetBIOSName
             $addr =  $Using:WSFCNode1PrivateIP2, $Using:WSFCNode2PrivateIP2, $Using:WSFCNode3PrivateIP2
-            New-Cluster -Name WSFCluster1 -Node $nodes -StaticAddress $addr
+            New-Cluster -Name $Using:WSFCName -Node $nodes -StaticAddress $addr
         }
     }
 

--- a/scripts/Set-Folder-Permissions.ps1
+++ b/scripts/Set-Folder-Permissions.ps1
@@ -1,5 +1,8 @@
 [CmdletBinding()]
 param(
+    [Parameter(Mandatory=$true)]
+    [string]
+    $WSFCName,
 
     [Parameter(Mandatory=$true)]
     [string]$DomainNetBIOSName,
@@ -54,7 +57,7 @@ Try{
 
     }
 
-    $obj = $DomainNetBIOSName + '\WSFCluster1$'
+    $obj = $DomainNetBIOSName + '\' + $WSFCName + '$'
     Invoke-Command -ScriptBlock $SetPermissions -ComputerName $FileServerNetBIOSName -Credential $DomainAdminCreds
 
     $obj = $DomainNetBIOSName + '\' + $SQLServiceAccount

--- a/templates/Template_1_SQL_AlwaysOn.template
+++ b/templates/Template_1_SQL_AlwaysOn.template
@@ -44,6 +44,13 @@
             "MaxLength": "15",
             "AllowedPattern": "[a-zA-Z0-9\\-]+"
         },
+        "WSFClusterName": {
+            "Description": "NetBIOS name of the Failover cluster virtual network",
+            "Default": "WSFCluster1",
+            "MaxLength": "15",
+            "MinLength": "1",
+            "Type": "String"
+        },
         "WSFCNode1NetBIOSName": {
             "Description": "NetBIOS name of the 1st WSFC Node (up to 15 characters)",
             "Type": "String",
@@ -1408,7 +1415,11 @@
                                     "Fn::Join": [
                                         "",
                                         [
-                                            "New-Cluster -Name WSFCluster1 -Node  ",
+                                            "New-Cluster -Name ",
+                                            {
+                                                "Ref": "WSFClusterName"
+                                            },
+                                            " -Node  ",
                                             {
                                                 "Ref": "WSFCNode1NetBIOSName"
                                             },
@@ -1627,7 +1638,11 @@
                                             {
                                                 "Ref": "DomainNetBIOSName"
                                             },
-                                            "\\WSFCluster1$','FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow');",
+                                            "\\",
+                                            {
+                                                "Ref": "WSFClusterName"
+                                            },
+                                            "$','FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow');",
                                             "    $acl.AddAccessRule($rule);",
                                             "    Set-Acl c:\\witness $acl",
                                             "} -ComputerName ",

--- a/templates/sql.template
+++ b/templates/sql.template
@@ -63,6 +63,7 @@
                         "default": "Failover Cluster Configuration"
                     },
                     "Parameters": [
+                        "WSFClusterName",
                         "WSFCFileServerInstanceType",
                         "WSFCFileServerNetBIOSName",
                         "WSFCFileServerPrivateIP",
@@ -189,6 +190,9 @@
                 },
                 "VPCID": {
                     "default": "VPC ID"
+                },
+                "WSFClusterName": {
+                    "default": "Failover cluster virtual network name account"
                 },
                 "WSFCFileServerInstanceType": {
                     "default": "File Server Instance Type"
@@ -463,6 +467,13 @@
             "Description": "ID of the VPC (e.g., vpc-0343606e)",
             "Type": "AWS::EC2::VPC::Id"
         },
+        "WSFClusterName": {
+            "Description": "NetBIOS name of the Failover cluster virtual network",
+            "Default": "WSFCluster1",
+            "MaxLength": "15",
+            "MinLength": "1",
+            "Type": "String"
+        },
         "WSFCFileServerInstanceType": {
             "Default": "t2.small",
             "Description": "Amazon EC2 instance type for a fileserver used to share install media, witness and replication folders",
@@ -649,7 +660,7 @@
         "Vol2IsIo1": {
             "Fn::Equals": [
                 {
-                    "Ref": "Volume1Type"
+                    "Ref": "Volume2Type"
                 },
                 "io1"
             ]
@@ -657,7 +668,7 @@
         "Vol3IsIo1": {
             "Fn::Equals": [
                 {
-                    "Ref": "Volume1Type"
+                    "Ref": "Volume2Type"
                 },
                 "io1"
             ]
@@ -3551,6 +3562,10 @@
                                         "",
                                         [
                                             "powershell.exe -ExecutionPolicy RemoteSigned -Command \"C:\\cfn\\scripts\\Configure-WSFC.ps1",
+                                            " -WSFCName ",
+                                            {
+                                                "Ref": "WSFClusterName"
+                                            },
                                             " -WSFCNode1PrivateIP2 ",
                                             {
                                                 "Ref": "WSFCNode1PrivateIP2"


### PR DESCRIPTION
The failover cluster virtual network name was hard-coded to WSFCluster1 preventing one from using this script to create a second cluster in the same directory. Added the ability to pass the virtual network name as a parameter.

Also fixed the conditions for Vol2IsIo1 and Vol3IsIo1 to make sure they were checking the correct volumes' type.