### PR TITLE
[Fix] Volume 2 & Volume 3 types were created the same as Volume 1

### DIFF
--- a/templates/sql.template
+++ b/templates/sql.template
@@ -667,7 +667,7 @@
         "Vol2IsIo1": {
             "Fn::Equals": [
                 {
-                    "Ref": "Volume1Type"
+                    "Ref": "Volume2Type"
                 },
                 "io1"
             ]
@@ -675,7 +675,7 @@
         "Vol3IsIo1": {
             "Fn::Equals": [
                 {
-                    "Ref": "Volume1Type"
+                    "Ref": "Volume3Type"
                 },
                 "io1"
             ]


### PR DESCRIPTION
`Template: quickstart-microsoft-sql/templates/sql.template`
Example: If Volume 1 Type is set as io1, then the same variable Volume1Type is used to create Volume 2 and Volume 3 as io1 as well. 

When different values are used for VolumeType for the three volumes, the stack creation fails because gp2 volume does not support IOPS parameter. 

*Issue #, if available:*
Fixes Github Issue #33

*Description of changes:*
Value for `Vol2IsIo1` is determined using the variable `Volume2Type` 
Value for `Vol3IsIo1` is determined using the variable` Volume3Type`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
