### PR TITLE
fixed dedicated logic host and use SSM Parameter to grab latest AMI

### DIFF
--- a/templates/Template_1_SQL_AlwaysOn.template
+++ b/templates/Template_1_SQL_AlwaysOn.template
@@ -195,55 +195,55 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.04.26"
+                "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.05.15"
             },
             "ap-northeast-1": {
-                "WS2012R2": "ami-046ee6b9fdfea3161"
+                "WS2012R2": "ami-0fb92ffbb15231067"
             },
             "ap-northeast-2": {
-                "WS2012R2": "ami-0025e3f1eacf7d130"
+                "WS2012R2": "ami-0bb1f41ebc1cfd531"
             },
             "ap-northeast-3": {
-                "WS2012R2": "ami-07db6e5406daf514a"
+                "WS2012R2": "ami-05113eaeef1e57872"
             },
             "ap-south-1": {
-                "WS2012R2": "ami-02f0a763aeda0077b"
+                "WS2012R2": "ami-0e7e244dcf61f05bd"
             },
             "ap-southeast-1": {
-                "WS2012R2": "ami-0a0a6f3903d43aedb"
+                "WS2012R2": "ami-0e1b9b93a7ae09d48"
             },
             "ap-southeast-2": {
-                "WS2012R2": "ami-011faffd94de75db6"
+                "WS2012R2": "ami-05fea4fe7550f15b1"
             },
             "ca-central-1": {
-                "WS2012R2": "ami-077d8740d7c88a083"
+                "WS2012R2": "ami-0cde2145f69e656f7"
             },
             "eu-central-1": {
-                "WS2012R2": "ami-02e33b7f1cfec85c3"
+                "WS2012R2": "ami-0f02af13cc03b7a82"
             },
             "eu-west-1": {
-                "WS2012R2": "ami-03cc072e1eb1504ad"
+                "WS2012R2": "ami-0d7808ca53cab7b99"
             },
             "eu-west-2": {
-                "WS2012R2": "ami-0ddbb61e1ac0b740c"
+                "WS2012R2": "ami-0408613824e63e2a7"
             },
             "eu-west-3": {
-                "WS2012R2": "ami-07c11c4d4df6d5a81"
+                "WS2012R2": "ami-0b1a41ab91a9c5df3"
             },
             "sa-east-1": {
-                "WS2012R2": "ami-06e9846cb29996e35"
+                "WS2012R2": "ami-06f2fe844c5bf85a3"
             },
             "us-east-1": {
-                "WS2012R2": "ami-0b6158cfa2ae7b493"
+                "WS2012R2": "ami-063e6917fb03cd4dd"
             },
             "us-east-2": {
-                "WS2012R2": "ami-0f33ca435060daee9"
+                "WS2012R2": "ami-0009a23b35b2d5db9"
             },
             "us-west-1": {
-                "WS2012R2": "ami-0d4f8a9abc53cca9c"
+                "WS2012R2": "ami-0c5a578433f91e821"
             },
             "us-west-2": {
-                "WS2012R2": "ami-00ddbceb28e44364c"
+                "WS2012R2": "ami-0898885648e61c67b"
             }
         }
     },

--- a/templates/Template_2_SQL_AlwaysOn.template
+++ b/templates/Template_2_SQL_AlwaysOn.template
@@ -82,55 +82,55 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.04.26"
+                "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.05.15"
             },
             "ap-northeast-1": {
-                "WS2012R2": "ami-046ee6b9fdfea3161"
+                "WS2012R2": "ami-0fb92ffbb15231067"
             },
             "ap-northeast-2": {
-                "WS2012R2": "ami-0025e3f1eacf7d130"
+                "WS2012R2": "ami-0bb1f41ebc1cfd531"
             },
             "ap-northeast-3": {
-                "WS2012R2": "ami-07db6e5406daf514a"
+                "WS2012R2": "ami-05113eaeef1e57872"
             },
             "ap-south-1": {
-                "WS2012R2": "ami-02f0a763aeda0077b"
+                "WS2012R2": "ami-0e7e244dcf61f05bd"
             },
             "ap-southeast-1": {
-                "WS2012R2": "ami-0a0a6f3903d43aedb"
+                "WS2012R2": "ami-0e1b9b93a7ae09d48"
             },
             "ap-southeast-2": {
-                "WS2012R2": "ami-011faffd94de75db6"
+                "WS2012R2": "ami-05fea4fe7550f15b1"
             },
             "ca-central-1": {
-                "WS2012R2": "ami-077d8740d7c88a083"
+                "WS2012R2": "ami-0cde2145f69e656f7"
             },
             "eu-central-1": {
-                "WS2012R2": "ami-02e33b7f1cfec85c3"
+                "WS2012R2": "ami-0f02af13cc03b7a82"
             },
             "eu-west-1": {
-                "WS2012R2": "ami-03cc072e1eb1504ad"
+                "WS2012R2": "ami-0d7808ca53cab7b99"
             },
             "eu-west-2": {
-                "WS2012R2": "ami-0ddbb61e1ac0b740c"
+                "WS2012R2": "ami-0408613824e63e2a7"
             },
             "eu-west-3": {
-                "WS2012R2": "ami-07c11c4d4df6d5a81"
+                "WS2012R2": "ami-0b1a41ab91a9c5df3"
             },
             "sa-east-1": {
-                "WS2012R2": "ami-06e9846cb29996e35"
+                "WS2012R2": "ami-06f2fe844c5bf85a3"
             },
             "us-east-1": {
-                "WS2012R2": "ami-0b6158cfa2ae7b493"
+                "WS2012R2": "ami-063e6917fb03cd4dd"
             },
             "us-east-2": {
-                "WS2012R2": "ami-0f33ca435060daee9"
+                "WS2012R2": "ami-0009a23b35b2d5db9"
             },
             "us-west-1": {
-                "WS2012R2": "ami-0d4f8a9abc53cca9c"
+                "WS2012R2": "ami-0c5a578433f91e821"
             },
             "us-west-2": {
-                "WS2012R2": "ami-00ddbceb28e44364c"
+                "WS2012R2": "ami-0898885648e61c67b"
             }
         }
     },

--- a/templates/sql.template
+++ b/templates/sql.template
@@ -750,94 +750,94 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "WS2016FULLBASE": "Windows_Server-2016-English-Full-Base-2019.04.26",
+                "WS2016FULLBASE": "Windows_Server-2016-English-Full-Base-2019.05.15",
                 "WS2016FULLSQL2016SP1ENT": "Windows_Server-2016-English-Full-SQL_2016_SP1_Enterprise-2019.02.13",
-                "WS2016FULLSQL2017ENT": "Windows_Server-2016-English-Full-SQL_2017_Enterprise-2019.04.26"
+                "WS2016FULLSQL2017ENT": "Windows_Server-2016-English-Full-SQL_2017_Enterprise-2019.05.15"
             },
             "ap-northeast-1": {
-                "WS2016FULLBASE": "ami-0db5a89b60f5ef7c6",
+                "WS2016FULLBASE": "ami-0b472d4d69a3b755b",
                 "WS2016FULLSQL2016SP1ENT": "ami-0d67d502d8f74cdd2",
-                "WS2016FULLSQL2017ENT": "ami-069b7a6e6853b0273"
+                "WS2016FULLSQL2017ENT": "ami-0b49ce2a254ed8ef1"
             },
             "ap-northeast-2": {
-                "WS2016FULLBASE": "ami-0a244c086008d4efd",
+                "WS2016FULLBASE": "ami-0058dddbdb8f29512",
                 "WS2016FULLSQL2016SP1ENT": "ami-047b6a1b01cd54dd8",
-                "WS2016FULLSQL2017ENT": "ami-08d5b1e70b09ddd71"
+                "WS2016FULLSQL2017ENT": "ami-0585446163b28bdac"
             },
             "ap-northeast-3": {
-                "WS2016FULLBASE": "ami-05ef103c5d8bba70c",
+                "WS2016FULLBASE": "ami-0cd9a2c56305274d2",
                 "WS2016FULLSQL2016SP1ENT": "ami-088fef6ee2a498f12",
-                "WS2016FULLSQL2017ENT": "ami-012edf14c292420fe"
+                "WS2016FULLSQL2017ENT": "ami-06be4f6ad7a9cfce0"
             },
             "ap-south-1": {
-                "WS2016FULLBASE": "ami-01f602ac7476d9e36",
+                "WS2016FULLBASE": "ami-032fbbaf32d503497",
                 "WS2016FULLSQL2016SP1ENT": "ami-0a4e5c5230e2f57d8",
-                "WS2016FULLSQL2017ENT": "ami-036364263ac27de0b"
+                "WS2016FULLSQL2017ENT": "ami-008fd831336e1197c"
             },
             "ap-southeast-1": {
-                "WS2016FULLBASE": "ami-012799a835ac6a1d0",
+                "WS2016FULLBASE": "ami-0e8ca15386ded5a7f",
                 "WS2016FULLSQL2016SP1ENT": "ami-0d04888fe33bba900",
-                "WS2016FULLSQL2017ENT": "ami-0114e4095c10d19b6"
+                "WS2016FULLSQL2017ENT": "ami-08a2a7b52c0bc055b"
             },
             "ap-southeast-2": {
-                "WS2016FULLBASE": "ami-0e96a0468179dce58",
+                "WS2016FULLBASE": "ami-01a5f3665934df1ca",
                 "WS2016FULLSQL2016SP1ENT": "ami-054db0905be229ea0",
-                "WS2016FULLSQL2017ENT": "ami-010b1965a530101b9"
+                "WS2016FULLSQL2017ENT": "ami-07eb709e75ab44064"
             },
             "ca-central-1": {
-                "WS2016FULLBASE": "ami-06850b219f7f8ec4d",
+                "WS2016FULLBASE": "ami-06fdabc69ab0cf769",
                 "WS2016FULLSQL2016SP1ENT": "ami-01d67a39f7ca62323",
-                "WS2016FULLSQL2017ENT": "ami-00e21e057ee5b0fea"
+                "WS2016FULLSQL2017ENT": "ami-020d0806ee9ec0f4a"
             },
             "eu-central-1": {
-                "WS2016FULLBASE": "ami-06732cfcceb36d206",
+                "WS2016FULLBASE": "ami-0db2f94d5e49a67a4",
                 "WS2016FULLSQL2016SP1ENT": "ami-0e7227dcbd25906aa",
-                "WS2016FULLSQL2017ENT": "ami-07901786677d1a5b7"
+                "WS2016FULLSQL2017ENT": "ami-0ecea362cc676d76f"
             },
             "eu-north-1": {
-                "WS2016FULLBASE": "ami-02ea3e2aae23d960c",
+                "WS2016FULLBASE": "ami-07b1ee004f0299c2c",
                 "WS2016FULLSQL2016SP1ENT": "ami-088c38a0c89476f30",
-                "WS2016FULLSQL2017ENT": "ami-002b958152dc10e1e"
+                "WS2016FULLSQL2017ENT": "ami-02e58149fc1b762fa"
             },
             "eu-west-1": {
-                "WS2016FULLBASE": "ami-08a92ed64caa44b84",
+                "WS2016FULLBASE": "ami-09437ffdb4f64a361",
                 "WS2016FULLSQL2016SP1ENT": "ami-081b12ff86ac97060",
-                "WS2016FULLSQL2017ENT": "ami-0b986ca47af68d081"
+                "WS2016FULLSQL2017ENT": "ami-007f62cba743e474a"
             },
             "eu-west-2": {
-                "WS2016FULLBASE": "ami-002b994906de0b994",
+                "WS2016FULLBASE": "ami-0f8e3bd4713dc814e",
                 "WS2016FULLSQL2016SP1ENT": "ami-0e2286224482a1fe7",
-                "WS2016FULLSQL2017ENT": "ami-0e3707cce33881a81"
+                "WS2016FULLSQL2017ENT": "ami-087f4d1cf8d33e349"
             },
             "eu-west-3": {
-                "WS2016FULLBASE": "ami-0a3421f99d36f7006",
+                "WS2016FULLBASE": "ami-0b0cc8d2d8f136b0e",
                 "WS2016FULLSQL2016SP1ENT": "ami-05f018f7dd68aeee5",
-                "WS2016FULLSQL2017ENT": "ami-045f6a3cfb2f6525f"
+                "WS2016FULLSQL2017ENT": "ami-0b69062bf6654e3c1"
             },
             "sa-east-1": {
-                "WS2016FULLBASE": "ami-0a926c6ebbb385ddf",
+                "WS2016FULLBASE": "ami-0a5811e71bd8b7bf0",
                 "WS2016FULLSQL2016SP1ENT": "ami-02905b98173fed3de",
-                "WS2016FULLSQL2017ENT": "ami-000e255328544719d"
+                "WS2016FULLSQL2017ENT": "ami-0bef0f931d46642c3"
             },
             "us-east-1": {
-                "WS2016FULLBASE": "ami-0a9d418cd78849a6c",
+                "WS2016FULLBASE": "ami-06bee8e1000e44ca4",
                 "WS2016FULLSQL2016SP1ENT": "ami-04927a7e3dd4ff841",
-                "WS2016FULLSQL2017ENT": "ami-065ab7a3b2218e3f7"
+                "WS2016FULLSQL2017ENT": "ami-05ff711eed05eae3a"
             },
             "us-east-2": {
-                "WS2016FULLBASE": "ami-0101a92481d57c1bc",
+                "WS2016FULLBASE": "ami-0838ffb5aea8de870",
                 "WS2016FULLSQL2016SP1ENT": "ami-0b10d5c3ae13b8685",
-                "WS2016FULLSQL2017ENT": "ami-06b0d9a675ab60cf4"
+                "WS2016FULLSQL2017ENT": "ami-0ff64db84ae667ca4"
             },
             "us-west-1": {
-                "WS2016FULLBASE": "ami-0d089c9a817ea8b89",
+                "WS2016FULLBASE": "ami-0453125a0771a994e",
                 "WS2016FULLSQL2016SP1ENT": "ami-00e44c002d8641eea",
-                "WS2016FULLSQL2017ENT": "ami-0084085b734bec6f3"
+                "WS2016FULLSQL2017ENT": "ami-0d3155e01308f68c5"
             },
             "us-west-2": {
-                "WS2016FULLBASE": "ami-0aa8349a37922c345",
+                "WS2016FULLBASE": "ami-07f35a597a32e470d",
                 "WS2016FULLSQL2016SP1ENT": "ami-0f4d3b5162a8e3fc2",
-                "WS2016FULLSQL2017ENT": "ami-06b1daaf6ef3617fc"
+                "WS2016FULLSQL2017ENT": "ami-08f288d4ceb2c3248"
             }
         },
         "SQLAMINameMap": {


### PR DESCRIPTION
*Issue #, if available:*
sql-master.template
- Configure HostType parameter to dedicated will trigger Dedicated Host stack creation. When dedicated instance is chosen, the stack should not create the dedicated host.
 
sql.template
- AMI IDs for SQL server that was defined in mapping were not publicly accessible
- Setting EC2 instance affinity to default while the tenancy is set to dedicated will fail EC2 instance creation.

*Description of changes:*
sql-master.template
- WSFCFileServerInstanceType parameter was defined but never being referenced in any resources. Reference this parameter in SQLStack resource
- Fix dedicated host stack logic. The dedicated host stack should only be created when HostType is Dedicated host.
- Removed dependsOn since dependency will be enforced when referencing other resource's output 

sql.template
- Removed unused IsThreeAz condition
- Removed AMI map, AMI reference was replaced with SSM Parameter
- Changed EC2 Instance Affinity, only set the value when using Dedicated Host
- minor changes on some of the property's value type, such as boolean, integer instead of a string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
