### PR TITLE
Remove comma causing errors in SetMaxDOP.ps1 (#51)

### DIFF
--- a/scripts/SetMaxDOP.ps1
+++ b/scripts/SetMaxDOP.ps1
@@ -19,10 +19,7 @@ param(
 
     [Parameter(Mandatory=$false)]
     [string]
-    $dop="30",
-
-
-
+    $dop="30"
 )
 
 try {


### PR DESCRIPTION
*Issue #, if available:*
51

*Description of changes:*
Fixes an error that causes stack creation to fail due to an extra comma in SetMaxDOP.ps1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
